### PR TITLE
feat(collab): AppMessage — generic app-defined pub-sub messages

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,13 +1,14 @@
 # MassRelay
 
 ## Version
-0.1.0
+0.1.1
 
 ## Provides
 - websocket-relay: Stateless WebSocket relay for real-time collaboration
 - room-routing: Room-based message routing
 - peer-management: Peer tracking with client_hint, session ownership, ownership transfer
 - collab-protocol: CollabAction/CollabEvent protobuf messaging protocol
+- app-message: generic app-defined pub-sub messages (AppMessage{kind,payload}), room-wide fan-out with no editor semantics — use massrelay as a message bus without the Scene/Text protocol
 - admin-api: Token-gated admin endpoints (/admin/status, /admin/rooms)
 - security-middleware: Origin allowlist, connection limiting, rate limiting, CSRF, trusted proxy
 - observability: OpenTelemetry metrics (Prometheus, OTLP), structured JSON logging (slog)
@@ -35,7 +36,7 @@ Requires Go 1.26.4+ (oneauth v0.1.36 minimum).
 ### Go Module
 ```go
 // go.mod
-require github.com/panyam/massrelay 0.1.0
+require github.com/panyam/massrelay 0.1.1
 
 // Local development
 replace github.com/panyam/massrelay => ~/newstack/massrelay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-07-31
+
+### Added
+- `AppMessage { kind, payload }` — a generic, app-defined pub-sub message added to
+  the collab protocol (`CollabAction`/`CollabEvent` oneofs). The relay fans it out
+  to the room unchanged, with **no server-side state and no editor semantics**, so
+  any application can use massrelay as a message bus without adopting the
+  Scene/Text editor protocol. The TypeScript client gains `sendAppMessage(kind,
+  payload)` and an `onAppMessage(kind, payload)` callback. Backward-compatible
+  (additive oneof fields).
+
 ## [0.1.0] - 2026-07-29
 
 First release since v0.0.11. Full write-up in

--- a/gen/go/massrelay/v1/models/collab.pb.go
+++ b/gen/go/massrelay/v1/models/collab.pb.go
@@ -7,13 +7,12 @@
 package models
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -40,6 +39,7 @@ type CollabAction struct {
 	//	*CollabAction_SceneInitResponse
 	//	*CollabAction_CredentialsChanged
 	//	*CollabAction_TitleChanged
+	//	*CollabAction_AppMessage
 	Action        isCollabAction_Action `protobuf_oneof:"action"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -193,6 +193,15 @@ func (x *CollabAction) GetTitleChanged() *TitleChanged {
 	return nil
 }
 
+func (x *CollabAction) GetAppMessage() *AppMessage {
+	if x != nil {
+		if x, ok := x.Action.(*CollabAction_AppMessage); ok {
+			return x.AppMessage
+		}
+	}
+	return nil
+}
+
 type isCollabAction_Action interface {
 	isCollabAction_Action()
 }
@@ -238,6 +247,13 @@ type CollabAction_TitleChanged struct {
 	TitleChanged *TitleChanged `protobuf:"bytes,19,opt,name=title_changed,json=titleChanged,proto3,oneof"`
 }
 
+type CollabAction_AppMessage struct {
+	// Generic, app-defined pub-sub message (no editor semantics). Relay-only:
+	// fanned out to the room unchanged, so any application can use massrelay as a
+	// message bus without adopting the editor (Scene/Text) protocol.
+	AppMessage *AppMessage `protobuf:"bytes,20,opt,name=app_message,json=appMessage,proto3,oneof"`
+}
+
 func (*CollabAction_Join) isCollabAction_Action() {}
 
 func (*CollabAction_Leave) isCollabAction_Action() {}
@@ -257,6 +273,8 @@ func (*CollabAction_SceneInitResponse) isCollabAction_Action() {}
 func (*CollabAction_CredentialsChanged) isCollabAction_Action() {}
 
 func (*CollabAction_TitleChanged) isCollabAction_Action() {}
+
+func (*CollabAction_AppMessage) isCollabAction_Action() {}
 
 type JoinRoom struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
@@ -817,6 +835,62 @@ func (x *SceneInitResponse) GetPayload() string {
 	return ""
 }
 
+// AppMessage is a generic, application-defined message the relay fans out to the
+// room unchanged (no server-side state, no editor semantics). kind is an
+// app-defined discriminator so peers route without decoding; payload is opaque
+// bytes whose schema the application owns.
+type AppMessage struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	Payload       []byte                 `protobuf:"bytes,2,opt,name=payload,proto3" json:"payload,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AppMessage) Reset() {
+	*x = AppMessage{}
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AppMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AppMessage) ProtoMessage() {}
+
+func (x *AppMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AppMessage.ProtoReflect.Descriptor instead.
+func (*AppMessage) Descriptor() ([]byte, []int) {
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *AppMessage) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *AppMessage) GetPayload() []byte {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
 type CollabEvent struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	EventId         string                 `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
@@ -838,6 +912,7 @@ type CollabEvent struct {
 	//	*CollabEvent_OwnerChanged
 	//	*CollabEvent_CredentialsChanged
 	//	*CollabEvent_TitleChanged
+	//	*CollabEvent_AppMessage
 	Event         isCollabEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -845,7 +920,7 @@ type CollabEvent struct {
 
 func (x *CollabEvent) Reset() {
 	*x = CollabEvent{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[10]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -857,7 +932,7 @@ func (x *CollabEvent) String() string {
 func (*CollabEvent) ProtoMessage() {}
 
 func (x *CollabEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[10]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -870,7 +945,7 @@ func (x *CollabEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CollabEvent.ProtoReflect.Descriptor instead.
 func (*CollabEvent) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{10}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *CollabEvent) GetEventId() string {
@@ -1027,6 +1102,15 @@ func (x *CollabEvent) GetTitleChanged() *TitleChanged {
 	return nil
 }
 
+func (x *CollabEvent) GetAppMessage() *AppMessage {
+	if x != nil {
+		if x, ok := x.Event.(*CollabEvent_AppMessage); ok {
+			return x.AppMessage
+		}
+	}
+	return nil
+}
+
 type isCollabEvent_Event interface {
 	isCollabEvent_Event()
 }
@@ -1088,6 +1172,12 @@ type CollabEvent_TitleChanged struct {
 	TitleChanged *TitleChanged `protobuf:"bytes,23,opt,name=title_changed,json=titleChanged,proto3,oneof"`
 }
 
+type CollabEvent_AppMessage struct {
+	// Generic, app-defined pub-sub message fanned out to the room (see the
+	// matching CollabAction.app_message).
+	AppMessage *AppMessage `protobuf:"bytes,24,opt,name=app_message,json=appMessage,proto3,oneof"`
+}
+
 func (*CollabEvent_RoomJoined) isCollabEvent_Event() {}
 
 func (*CollabEvent_PeerJoined) isCollabEvent_Event() {}
@@ -1116,6 +1206,8 @@ func (*CollabEvent_CredentialsChanged) isCollabEvent_Event() {}
 
 func (*CollabEvent_TitleChanged) isCollabEvent_Event() {}
 
+func (*CollabEvent_AppMessage) isCollabEvent_Event() {}
+
 // Room captures the canonical state of a collaboration session.
 // Composed into RoomJoined and GetRoomResponse to avoid field duplication.
 type Room struct {
@@ -1133,7 +1225,7 @@ type Room struct {
 
 func (x *Room) Reset() {
 	*x = Room{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[11]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1145,7 +1237,7 @@ func (x *Room) String() string {
 func (*Room) ProtoMessage() {}
 
 func (x *Room) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[11]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1158,7 +1250,7 @@ func (x *Room) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Room.ProtoReflect.Descriptor instead.
 func (*Room) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{11}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *Room) GetSessionId() string {
@@ -1222,7 +1314,7 @@ type RoomJoined struct {
 
 func (x *RoomJoined) Reset() {
 	*x = RoomJoined{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[12]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1234,7 +1326,7 @@ func (x *RoomJoined) String() string {
 func (*RoomJoined) ProtoMessage() {}
 
 func (x *RoomJoined) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[12]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1247,7 +1339,7 @@ func (x *RoomJoined) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomJoined.ProtoReflect.Descriptor instead.
 func (*RoomJoined) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{12}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *RoomJoined) GetClientId() string {
@@ -1293,7 +1385,7 @@ type PeerInfo struct {
 
 func (x *PeerInfo) Reset() {
 	*x = PeerInfo{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[13]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1305,7 +1397,7 @@ func (x *PeerInfo) String() string {
 func (*PeerInfo) ProtoMessage() {}
 
 func (x *PeerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[13]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1318,7 +1410,7 @@ func (x *PeerInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeerInfo.ProtoReflect.Descriptor instead.
 func (*PeerInfo) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{13}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PeerInfo) GetClientId() string {
@@ -1379,7 +1471,7 @@ type PeerJoined struct {
 
 func (x *PeerJoined) Reset() {
 	*x = PeerJoined{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[14]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1391,7 +1483,7 @@ func (x *PeerJoined) String() string {
 func (*PeerJoined) ProtoMessage() {}
 
 func (x *PeerJoined) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[14]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1404,7 +1496,7 @@ func (x *PeerJoined) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeerJoined.ProtoReflect.Descriptor instead.
 func (*PeerJoined) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{14}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *PeerJoined) GetPeer() *PeerInfo {
@@ -1425,7 +1517,7 @@ type PeerLeft struct {
 
 func (x *PeerLeft) Reset() {
 	*x = PeerLeft{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[15]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1437,7 +1529,7 @@ func (x *PeerLeft) String() string {
 func (*PeerLeft) ProtoMessage() {}
 
 func (x *PeerLeft) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[15]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1450,7 +1542,7 @@ func (x *PeerLeft) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeerLeft.ProtoReflect.Descriptor instead.
 func (*PeerLeft) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{15}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *PeerLeft) GetClientId() string {
@@ -1484,7 +1576,7 @@ type ErrorEvent struct {
 
 func (x *ErrorEvent) Reset() {
 	*x = ErrorEvent{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[16]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1496,7 +1588,7 @@ func (x *ErrorEvent) String() string {
 func (*ErrorEvent) ProtoMessage() {}
 
 func (x *ErrorEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[16]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1509,7 +1601,7 @@ func (x *ErrorEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ErrorEvent.ProtoReflect.Descriptor instead.
 func (*ErrorEvent) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{16}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ErrorEvent) GetCode() string {
@@ -1535,7 +1627,7 @@ type SessionEnded struct {
 
 func (x *SessionEnded) Reset() {
 	*x = SessionEnded{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[17]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1547,7 +1639,7 @@ func (x *SessionEnded) String() string {
 func (*SessionEnded) ProtoMessage() {}
 
 func (x *SessionEnded) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[17]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1560,7 +1652,7 @@ func (x *SessionEnded) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionEnded.ProtoReflect.Descriptor instead.
 func (*SessionEnded) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{17}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SessionEnded) GetReason() string {
@@ -1579,7 +1671,7 @@ type OwnerChanged struct {
 
 func (x *OwnerChanged) Reset() {
 	*x = OwnerChanged{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[18]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1591,7 +1683,7 @@ func (x *OwnerChanged) String() string {
 func (*OwnerChanged) ProtoMessage() {}
 
 func (x *OwnerChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[18]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1604,7 +1696,7 @@ func (x *OwnerChanged) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OwnerChanged.ProtoReflect.Descriptor instead.
 func (*OwnerChanged) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{18}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *OwnerChanged) GetNewOwnerClientId() string {
@@ -1623,7 +1715,7 @@ type CredentialsChanged struct {
 
 func (x *CredentialsChanged) Reset() {
 	*x = CredentialsChanged{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[19]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1635,7 +1727,7 @@ func (x *CredentialsChanged) String() string {
 func (*CredentialsChanged) ProtoMessage() {}
 
 func (x *CredentialsChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[19]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1648,7 +1740,7 @@ func (x *CredentialsChanged) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CredentialsChanged.ProtoReflect.Descriptor instead.
 func (*CredentialsChanged) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{19}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CredentialsChanged) GetReason() string {
@@ -1667,7 +1759,7 @@ type TitleChanged struct {
 
 func (x *TitleChanged) Reset() {
 	*x = TitleChanged{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[20]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1679,7 +1771,7 @@ func (x *TitleChanged) String() string {
 func (*TitleChanged) ProtoMessage() {}
 
 func (x *TitleChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[20]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1692,7 +1784,7 @@ func (x *TitleChanged) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TitleChanged.ProtoReflect.Descriptor instead.
 func (*TitleChanged) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{20}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TitleChanged) GetTitle() string {
@@ -1711,7 +1803,7 @@ type GetRoomRequest struct {
 
 func (x *GetRoomRequest) Reset() {
 	*x = GetRoomRequest{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[21]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1723,7 +1815,7 @@ func (x *GetRoomRequest) String() string {
 func (*GetRoomRequest) ProtoMessage() {}
 
 func (x *GetRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[21]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1736,7 +1828,7 @@ func (x *GetRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomRequest.ProtoReflect.Descriptor instead.
 func (*GetRoomRequest) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{21}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetRoomRequest) GetSessionId() string {
@@ -1755,7 +1847,7 @@ type GetRoomResponse struct {
 
 func (x *GetRoomResponse) Reset() {
 	*x = GetRoomResponse{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[22]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1767,7 +1859,7 @@ func (x *GetRoomResponse) String() string {
 func (*GetRoomResponse) ProtoMessage() {}
 
 func (x *GetRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[22]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1780,7 +1872,7 @@ func (x *GetRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomResponse.ProtoReflect.Descriptor instead.
 func (*GetRoomResponse) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{22}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetRoomResponse) GetRoom() *Room {
@@ -1798,7 +1890,7 @@ type ListRoomsRequest struct {
 
 func (x *ListRoomsRequest) Reset() {
 	*x = ListRoomsRequest{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[23]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1810,7 +1902,7 @@ func (x *ListRoomsRequest) String() string {
 func (*ListRoomsRequest) ProtoMessage() {}
 
 func (x *ListRoomsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[23]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1823,7 +1915,7 @@ func (x *ListRoomsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoomsRequest) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{23}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{24}
 }
 
 type ListRoomsResponse struct {
@@ -1835,7 +1927,7 @@ type ListRoomsResponse struct {
 
 func (x *ListRoomsResponse) Reset() {
 	*x = ListRoomsResponse{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[24]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1847,7 +1939,7 @@ func (x *ListRoomsResponse) String() string {
 func (*ListRoomsResponse) ProtoMessage() {}
 
 func (x *ListRoomsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[24]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1860,7 +1952,7 @@ func (x *ListRoomsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoomsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoomsResponse) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{24}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ListRoomsResponse) GetRooms() []*RoomSummary {
@@ -1881,7 +1973,7 @@ type RoomSummary struct {
 
 func (x *RoomSummary) Reset() {
 	*x = RoomSummary{}
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[25]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1893,7 +1985,7 @@ func (x *RoomSummary) String() string {
 func (*RoomSummary) ProtoMessage() {}
 
 func (x *RoomSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_massrelay_v1_models_collab_proto_msgTypes[25]
+	mi := &file_massrelay_v1_models_collab_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1906,7 +1998,7 @@ func (x *RoomSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomSummary.ProtoReflect.Descriptor instead.
 func (*RoomSummary) Descriptor() ([]byte, []int) {
-	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{25}
+	return file_massrelay_v1_models_collab_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *RoomSummary) GetSessionId() string {
@@ -1934,7 +2026,7 @@ var File_massrelay_v1_models_collab_proto protoreflect.FileDescriptor
 
 const file_massrelay_v1_models_collab_proto_rawDesc = "" +
 	"\n" +
-	" massrelay/v1/models/collab.proto\x12\x13massrelay.v1.models\x1a\x1fgoogle/protobuf/timestamp.proto\"\xcc\x06\n" +
+	" massrelay/v1/models/collab.proto\x12\x13massrelay.v1.models\x1a\x1fgoogle/protobuf/timestamp.proto\"\x90\a\n" +
 	"\fCollabAction\x12\x1b\n" +
 	"\taction_id\x18\x01 \x01(\tR\bactionId\x12\x1b\n" +
 	"\tclient_id\x18\x02 \x01(\tR\bclientId\x12\x1c\n" +
@@ -1950,7 +2042,9 @@ const file_massrelay_v1_models_collab_proto_rawDesc = "" +
 	"\x12scene_init_request\x18\x10 \x01(\v2%.massrelay.v1.models.SceneInitRequestH\x00R\x10sceneInitRequest\x12X\n" +
 	"\x13scene_init_response\x18\x11 \x01(\v2&.massrelay.v1.models.SceneInitResponseH\x00R\x11sceneInitResponse\x12Z\n" +
 	"\x13credentials_changed\x18\x12 \x01(\v2'.massrelay.v1.models.CredentialsChangedH\x00R\x12credentialsChanged\x12H\n" +
-	"\rtitle_changed\x18\x13 \x01(\v2!.massrelay.v1.models.TitleChangedH\x00R\ftitleChangedB\b\n" +
+	"\rtitle_changed\x18\x13 \x01(\v2!.massrelay.v1.models.TitleChangedH\x00R\ftitleChanged\x12B\n" +
+	"\vapp_message\x18\x14 \x01(\v2\x1f.massrelay.v1.models.AppMessageH\x00R\n" +
+	"appMessageB\b\n" +
 	"\x06action\"\xc5\x03\n" +
 	"\bJoinRoom\x12\x1d\n" +
 	"\n" +
@@ -2002,7 +2096,11 @@ const file_massrelay_v1_models_collab_proto_rawDesc = "" +
 	"\x0fcursor_position\x18\x03 \x01(\x05R\x0ecursorPosition\"\x12\n" +
 	"\x10SceneInitRequest\"-\n" +
 	"\x11SceneInitResponse\x12\x18\n" +
-	"\apayload\x18\x01 \x01(\tR\apayload\"\x84\t\n" +
+	"\apayload\x18\x01 \x01(\tR\apayload\":\n" +
+	"\n" +
+	"AppMessage\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x18\n" +
+	"\apayload\x18\x02 \x01(\fR\apayload\"\xc8\t\n" +
 	"\vCollabEvent\x12\x19\n" +
 	"\bevent_id\x18\x01 \x01(\tR\aeventId\x12$\n" +
 	"\x0efrom_client_id\x18\x02 \x01(\tR\ffromClientId\x12)\n" +
@@ -2024,7 +2122,9 @@ const file_massrelay_v1_models_collab_proto_rawDesc = "" +
 	"\rsession_ended\x18\x14 \x01(\v2!.massrelay.v1.models.SessionEndedH\x00R\fsessionEnded\x12H\n" +
 	"\rowner_changed\x18\x15 \x01(\v2!.massrelay.v1.models.OwnerChangedH\x00R\fownerChanged\x12Z\n" +
 	"\x13credentials_changed\x18\x16 \x01(\v2'.massrelay.v1.models.CredentialsChangedH\x00R\x12credentialsChanged\x12H\n" +
-	"\rtitle_changed\x18\x17 \x01(\v2!.massrelay.v1.models.TitleChangedH\x00R\ftitleChangedB\a\n" +
+	"\rtitle_changed\x18\x17 \x01(\v2!.massrelay.v1.models.TitleChangedH\x00R\ftitleChanged\x12B\n" +
+	"\vapp_message\x18\x18 \x01(\v2\x1f.massrelay.v1.models.AppMessageH\x00R\n" +
+	"appMessageB\a\n" +
 	"\x05event\"\xd3\x03\n" +
 	"\x04Room\x12\x1d\n" +
 	"\n" +
@@ -2111,7 +2211,7 @@ func file_massrelay_v1_models_collab_proto_rawDescGZIP() []byte {
 	return file_massrelay_v1_models_collab_proto_rawDescData
 }
 
-var file_massrelay_v1_models_collab_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_massrelay_v1_models_collab_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_massrelay_v1_models_collab_proto_goTypes = []any{
 	(*CollabAction)(nil),          // 0: massrelay.v1.models.CollabAction
 	(*JoinRoom)(nil),              // 1: massrelay.v1.models.JoinRoom
@@ -2123,28 +2223,29 @@ var file_massrelay_v1_models_collab_proto_goTypes = []any{
 	(*TextUpdate)(nil),            // 7: massrelay.v1.models.TextUpdate
 	(*SceneInitRequest)(nil),      // 8: massrelay.v1.models.SceneInitRequest
 	(*SceneInitResponse)(nil),     // 9: massrelay.v1.models.SceneInitResponse
-	(*CollabEvent)(nil),           // 10: massrelay.v1.models.CollabEvent
-	(*Room)(nil),                  // 11: massrelay.v1.models.Room
-	(*RoomJoined)(nil),            // 12: massrelay.v1.models.RoomJoined
-	(*PeerInfo)(nil),              // 13: massrelay.v1.models.PeerInfo
-	(*PeerJoined)(nil),            // 14: massrelay.v1.models.PeerJoined
-	(*PeerLeft)(nil),              // 15: massrelay.v1.models.PeerLeft
-	(*ErrorEvent)(nil),            // 16: massrelay.v1.models.ErrorEvent
-	(*SessionEnded)(nil),          // 17: massrelay.v1.models.SessionEnded
-	(*OwnerChanged)(nil),          // 18: massrelay.v1.models.OwnerChanged
-	(*CredentialsChanged)(nil),    // 19: massrelay.v1.models.CredentialsChanged
-	(*TitleChanged)(nil),          // 20: massrelay.v1.models.TitleChanged
-	(*GetRoomRequest)(nil),        // 21: massrelay.v1.models.GetRoomRequest
-	(*GetRoomResponse)(nil),       // 22: massrelay.v1.models.GetRoomResponse
-	(*ListRoomsRequest)(nil),      // 23: massrelay.v1.models.ListRoomsRequest
-	(*ListRoomsResponse)(nil),     // 24: massrelay.v1.models.ListRoomsResponse
-	(*RoomSummary)(nil),           // 25: massrelay.v1.models.RoomSummary
-	nil,                           // 26: massrelay.v1.models.JoinRoom.MetadataEntry
-	nil,                           // 27: massrelay.v1.models.CursorUpdate.SelectedElementIdsEntry
-	nil,                           // 28: massrelay.v1.models.Room.PeersEntry
-	nil,                           // 29: massrelay.v1.models.Room.MetadataEntry
-	nil,                           // 30: massrelay.v1.models.PeerInfo.MetadataEntry
-	(*timestamppb.Timestamp)(nil), // 31: google.protobuf.Timestamp
+	(*AppMessage)(nil),            // 10: massrelay.v1.models.AppMessage
+	(*CollabEvent)(nil),           // 11: massrelay.v1.models.CollabEvent
+	(*Room)(nil),                  // 12: massrelay.v1.models.Room
+	(*RoomJoined)(nil),            // 13: massrelay.v1.models.RoomJoined
+	(*PeerInfo)(nil),              // 14: massrelay.v1.models.PeerInfo
+	(*PeerJoined)(nil),            // 15: massrelay.v1.models.PeerJoined
+	(*PeerLeft)(nil),              // 16: massrelay.v1.models.PeerLeft
+	(*ErrorEvent)(nil),            // 17: massrelay.v1.models.ErrorEvent
+	(*SessionEnded)(nil),          // 18: massrelay.v1.models.SessionEnded
+	(*OwnerChanged)(nil),          // 19: massrelay.v1.models.OwnerChanged
+	(*CredentialsChanged)(nil),    // 20: massrelay.v1.models.CredentialsChanged
+	(*TitleChanged)(nil),          // 21: massrelay.v1.models.TitleChanged
+	(*GetRoomRequest)(nil),        // 22: massrelay.v1.models.GetRoomRequest
+	(*GetRoomResponse)(nil),       // 23: massrelay.v1.models.GetRoomResponse
+	(*ListRoomsRequest)(nil),      // 24: massrelay.v1.models.ListRoomsRequest
+	(*ListRoomsResponse)(nil),     // 25: massrelay.v1.models.ListRoomsResponse
+	(*RoomSummary)(nil),           // 26: massrelay.v1.models.RoomSummary
+	nil,                           // 27: massrelay.v1.models.JoinRoom.MetadataEntry
+	nil,                           // 28: massrelay.v1.models.CursorUpdate.SelectedElementIdsEntry
+	nil,                           // 29: massrelay.v1.models.Room.PeersEntry
+	nil,                           // 30: massrelay.v1.models.Room.MetadataEntry
+	nil,                           // 31: massrelay.v1.models.PeerInfo.MetadataEntry
+	(*timestamppb.Timestamp)(nil), // 32: google.protobuf.Timestamp
 }
 var file_massrelay_v1_models_collab_proto_depIdxs = []int32{
 	1,  // 0: massrelay.v1.models.CollabAction.join:type_name -> massrelay.v1.models.JoinRoom
@@ -2155,40 +2256,42 @@ var file_massrelay_v1_models_collab_proto_depIdxs = []int32{
 	7,  // 5: massrelay.v1.models.CollabAction.text_update:type_name -> massrelay.v1.models.TextUpdate
 	8,  // 6: massrelay.v1.models.CollabAction.scene_init_request:type_name -> massrelay.v1.models.SceneInitRequest
 	9,  // 7: massrelay.v1.models.CollabAction.scene_init_response:type_name -> massrelay.v1.models.SceneInitResponse
-	19, // 8: massrelay.v1.models.CollabAction.credentials_changed:type_name -> massrelay.v1.models.CredentialsChanged
-	20, // 9: massrelay.v1.models.CollabAction.title_changed:type_name -> massrelay.v1.models.TitleChanged
-	26, // 10: massrelay.v1.models.JoinRoom.metadata:type_name -> massrelay.v1.models.JoinRoom.MetadataEntry
-	5,  // 11: massrelay.v1.models.SceneUpdate.elements:type_name -> massrelay.v1.models.ElementUpdate
-	27, // 12: massrelay.v1.models.CursorUpdate.selected_element_ids:type_name -> massrelay.v1.models.CursorUpdate.SelectedElementIdsEntry
-	12, // 13: massrelay.v1.models.CollabEvent.room_joined:type_name -> massrelay.v1.models.RoomJoined
-	14, // 14: massrelay.v1.models.CollabEvent.peer_joined:type_name -> massrelay.v1.models.PeerJoined
-	15, // 15: massrelay.v1.models.CollabEvent.peer_left:type_name -> massrelay.v1.models.PeerLeft
-	3,  // 16: massrelay.v1.models.CollabEvent.presence:type_name -> massrelay.v1.models.PresenceUpdate
-	4,  // 17: massrelay.v1.models.CollabEvent.scene_update:type_name -> massrelay.v1.models.SceneUpdate
-	6,  // 18: massrelay.v1.models.CollabEvent.cursor_update:type_name -> massrelay.v1.models.CursorUpdate
-	7,  // 19: massrelay.v1.models.CollabEvent.text_update:type_name -> massrelay.v1.models.TextUpdate
-	9,  // 20: massrelay.v1.models.CollabEvent.scene_init_response:type_name -> massrelay.v1.models.SceneInitResponse
-	16, // 21: massrelay.v1.models.CollabEvent.error:type_name -> massrelay.v1.models.ErrorEvent
-	8,  // 22: massrelay.v1.models.CollabEvent.scene_init_request:type_name -> massrelay.v1.models.SceneInitRequest
-	17, // 23: massrelay.v1.models.CollabEvent.session_ended:type_name -> massrelay.v1.models.SessionEnded
-	18, // 24: massrelay.v1.models.CollabEvent.owner_changed:type_name -> massrelay.v1.models.OwnerChanged
-	19, // 25: massrelay.v1.models.CollabEvent.credentials_changed:type_name -> massrelay.v1.models.CredentialsChanged
-	20, // 26: massrelay.v1.models.CollabEvent.title_changed:type_name -> massrelay.v1.models.TitleChanged
-	28, // 27: massrelay.v1.models.Room.peers:type_name -> massrelay.v1.models.Room.PeersEntry
-	31, // 28: massrelay.v1.models.Room.created_at:type_name -> google.protobuf.Timestamp
-	29, // 29: massrelay.v1.models.Room.metadata:type_name -> massrelay.v1.models.Room.MetadataEntry
-	11, // 30: massrelay.v1.models.RoomJoined.room:type_name -> massrelay.v1.models.Room
-	30, // 31: massrelay.v1.models.PeerInfo.metadata:type_name -> massrelay.v1.models.PeerInfo.MetadataEntry
-	13, // 32: massrelay.v1.models.PeerJoined.peer:type_name -> massrelay.v1.models.PeerInfo
-	11, // 33: massrelay.v1.models.GetRoomResponse.room:type_name -> massrelay.v1.models.Room
-	25, // 34: massrelay.v1.models.ListRoomsResponse.rooms:type_name -> massrelay.v1.models.RoomSummary
-	31, // 35: massrelay.v1.models.RoomSummary.created_at:type_name -> google.protobuf.Timestamp
-	13, // 36: massrelay.v1.models.Room.PeersEntry.value:type_name -> massrelay.v1.models.PeerInfo
-	37, // [37:37] is the sub-list for method output_type
-	37, // [37:37] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	20, // 8: massrelay.v1.models.CollabAction.credentials_changed:type_name -> massrelay.v1.models.CredentialsChanged
+	21, // 9: massrelay.v1.models.CollabAction.title_changed:type_name -> massrelay.v1.models.TitleChanged
+	10, // 10: massrelay.v1.models.CollabAction.app_message:type_name -> massrelay.v1.models.AppMessage
+	27, // 11: massrelay.v1.models.JoinRoom.metadata:type_name -> massrelay.v1.models.JoinRoom.MetadataEntry
+	5,  // 12: massrelay.v1.models.SceneUpdate.elements:type_name -> massrelay.v1.models.ElementUpdate
+	28, // 13: massrelay.v1.models.CursorUpdate.selected_element_ids:type_name -> massrelay.v1.models.CursorUpdate.SelectedElementIdsEntry
+	13, // 14: massrelay.v1.models.CollabEvent.room_joined:type_name -> massrelay.v1.models.RoomJoined
+	15, // 15: massrelay.v1.models.CollabEvent.peer_joined:type_name -> massrelay.v1.models.PeerJoined
+	16, // 16: massrelay.v1.models.CollabEvent.peer_left:type_name -> massrelay.v1.models.PeerLeft
+	3,  // 17: massrelay.v1.models.CollabEvent.presence:type_name -> massrelay.v1.models.PresenceUpdate
+	4,  // 18: massrelay.v1.models.CollabEvent.scene_update:type_name -> massrelay.v1.models.SceneUpdate
+	6,  // 19: massrelay.v1.models.CollabEvent.cursor_update:type_name -> massrelay.v1.models.CursorUpdate
+	7,  // 20: massrelay.v1.models.CollabEvent.text_update:type_name -> massrelay.v1.models.TextUpdate
+	9,  // 21: massrelay.v1.models.CollabEvent.scene_init_response:type_name -> massrelay.v1.models.SceneInitResponse
+	17, // 22: massrelay.v1.models.CollabEvent.error:type_name -> massrelay.v1.models.ErrorEvent
+	8,  // 23: massrelay.v1.models.CollabEvent.scene_init_request:type_name -> massrelay.v1.models.SceneInitRequest
+	18, // 24: massrelay.v1.models.CollabEvent.session_ended:type_name -> massrelay.v1.models.SessionEnded
+	19, // 25: massrelay.v1.models.CollabEvent.owner_changed:type_name -> massrelay.v1.models.OwnerChanged
+	20, // 26: massrelay.v1.models.CollabEvent.credentials_changed:type_name -> massrelay.v1.models.CredentialsChanged
+	21, // 27: massrelay.v1.models.CollabEvent.title_changed:type_name -> massrelay.v1.models.TitleChanged
+	10, // 28: massrelay.v1.models.CollabEvent.app_message:type_name -> massrelay.v1.models.AppMessage
+	29, // 29: massrelay.v1.models.Room.peers:type_name -> massrelay.v1.models.Room.PeersEntry
+	32, // 30: massrelay.v1.models.Room.created_at:type_name -> google.protobuf.Timestamp
+	30, // 31: massrelay.v1.models.Room.metadata:type_name -> massrelay.v1.models.Room.MetadataEntry
+	12, // 32: massrelay.v1.models.RoomJoined.room:type_name -> massrelay.v1.models.Room
+	31, // 33: massrelay.v1.models.PeerInfo.metadata:type_name -> massrelay.v1.models.PeerInfo.MetadataEntry
+	14, // 34: massrelay.v1.models.PeerJoined.peer:type_name -> massrelay.v1.models.PeerInfo
+	12, // 35: massrelay.v1.models.GetRoomResponse.room:type_name -> massrelay.v1.models.Room
+	26, // 36: massrelay.v1.models.ListRoomsResponse.rooms:type_name -> massrelay.v1.models.RoomSummary
+	32, // 37: massrelay.v1.models.RoomSummary.created_at:type_name -> google.protobuf.Timestamp
+	14, // 38: massrelay.v1.models.Room.PeersEntry.value:type_name -> massrelay.v1.models.PeerInfo
+	39, // [39:39] is the sub-list for method output_type
+	39, // [39:39] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_massrelay_v1_models_collab_proto_init() }
@@ -2207,8 +2310,9 @@ func file_massrelay_v1_models_collab_proto_init() {
 		(*CollabAction_SceneInitResponse)(nil),
 		(*CollabAction_CredentialsChanged)(nil),
 		(*CollabAction_TitleChanged)(nil),
+		(*CollabAction_AppMessage)(nil),
 	}
-	file_massrelay_v1_models_collab_proto_msgTypes[10].OneofWrappers = []any{
+	file_massrelay_v1_models_collab_proto_msgTypes[11].OneofWrappers = []any{
 		(*CollabEvent_RoomJoined)(nil),
 		(*CollabEvent_PeerJoined)(nil),
 		(*CollabEvent_PeerLeft)(nil),
@@ -2223,6 +2327,7 @@ func file_massrelay_v1_models_collab_proto_init() {
 		(*CollabEvent_OwnerChanged)(nil),
 		(*CollabEvent_CredentialsChanged)(nil),
 		(*CollabEvent_TitleChanged)(nil),
+		(*CollabEvent_AppMessage)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2230,7 +2335,7 @@ func file_massrelay_v1_models_collab_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_massrelay_v1_models_collab_proto_rawDesc), len(file_massrelay_v1_models_collab_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   31,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/go/massrelay/v1/services/collab.pb.go
+++ b/gen/go/massrelay/v1/services/collab.pb.go
@@ -7,12 +7,11 @@
 package services
 
 import (
-	reflect "reflect"
-	unsafe "unsafe"
-
 	models "github.com/panyam/massrelay/gen/go/massrelay/v1/models"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 const (

--- a/gen/go/massrelay/v1/services/collab_grpc.pb.go
+++ b/gen/go/massrelay/v1/services/collab_grpc.pb.go
@@ -8,7 +8,6 @@ package services
 
 import (
 	context "context"
-
 	models "github.com/panyam/massrelay/gen/go/massrelay/v1/models"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"

--- a/gen/go/massrelay/v1/services/servicesconnect/collab.connect.go
+++ b/gen/go/massrelay/v1/services/servicesconnect/collab.connect.go
@@ -5,14 +5,13 @@
 package servicesconnect
 
 import (
+	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	http "net/http"
-	strings "strings"
-
-	connect "connectrpc.com/connect"
 	models "github.com/panyam/massrelay/gen/go/massrelay/v1/models"
 	services "github.com/panyam/massrelay/gen/go/massrelay/v1/services"
+	http "net/http"
+	strings "strings"
 )
 
 // This is a compile-time assertion to ensure that this generated file and the connect package are

--- a/protos/massrelay/v1/models/collab.proto
+++ b/protos/massrelay/v1/models/collab.proto
@@ -24,6 +24,10 @@ message CollabAction {
     SceneInitResponse scene_init_response = 17;
     CredentialsChanged credentials_changed = 18;
     TitleChanged title_changed = 19;
+    // Generic, app-defined pub-sub message (no editor semantics). Relay-only:
+    // fanned out to the room unchanged, so any application can use massrelay as a
+    // message bus without adopting the editor (Scene/Text) protocol.
+    AppMessage app_message = 20;
   }
 }
 
@@ -85,6 +89,15 @@ message SceneInitResponse {
   string payload = 1;
 }
 
+// AppMessage is a generic, application-defined message the relay fans out to the
+// room unchanged (no server-side state, no editor semantics). kind is an
+// app-defined discriminator so peers route without decoding; payload is opaque
+// bytes whose schema the application owns.
+message AppMessage {
+  string kind = 1;
+  bytes payload = 2;
+}
+
 // ─── Server → Client ────────────────────────────
 
 message CollabEvent {
@@ -108,6 +121,9 @@ message CollabEvent {
     OwnerChanged owner_changed = 21;
     CredentialsChanged credentials_changed = 22;
     TitleChanged title_changed = 23;
+    // Generic, app-defined pub-sub message fanned out to the room (see the
+    // matching CollabAction.app_message).
+    AppMessage app_message = 24;
   }
 }
 

--- a/services/broadcast_test.go
+++ b/services/broadcast_test.go
@@ -248,3 +248,57 @@ func TestCredentialsChanged_Broadcast(t *testing.T) {
 		t.Fatal("expected CredentialsChanged event on peer channel")
 	}
 }
+
+func TestBroadcastAppMessage(t *testing.T) {
+	svc := NewCollabService()
+	ctx := context.Background()
+
+	joinAction := func(name string) string {
+		action := &pb.CollabAction{
+			Action: &pb.CollabAction_Join{
+				Join: &pb.JoinRoom{SessionId: "sessAM", Username: name, Metadata: map[string]string{"tool": "diffpp"}},
+			},
+		}
+		event, _ := svc.HandleAction(ctx, action)
+		return event.GetRoomJoined().GetClientId()
+	}
+	clientId1 := joinAction("window1")
+	clientId2 := joinAction("window2")
+
+	// Drain window1's PeerJoined for window2.
+	<-svc.GetRoomByID("sessAM").Clients[clientId1].SendCh
+
+	// window2 publishes a generic app message.
+	payload := []byte(`{"requestId":"r1","markdown":"the answer"}`)
+	action := &pb.CollabAction{
+		ClientId: clientId2,
+		Action:   &pb.CollabAction_AppMessage{AppMessage: &pb.AppMessage{Kind: "answer", Payload: payload}},
+	}
+	if _, err := svc.HandleAction(ctx, action); err != nil {
+		t.Fatalf("broadcast error: %v", err)
+	}
+
+	room := svc.GetRoomByID("sessAM")
+	// window1 (the other peer) receives it verbatim.
+	select {
+	case evt := <-room.Clients[clientId1].SendCh:
+		am := evt.GetAppMessage()
+		if am == nil {
+			t.Fatalf("expected AppMessage event, got %T", evt.Event)
+		}
+		if am.GetKind() != "answer" || string(am.GetPayload()) != string(payload) {
+			t.Fatalf("app message not fanned out verbatim: kind=%q payload=%q", am.GetKind(), am.GetPayload())
+		}
+	default:
+		t.Fatal("window1 should have received the AppMessage broadcast")
+	}
+
+	// The sender (window2) must NOT receive its own message (BroadcastExcept).
+	select {
+	case evt := <-room.Clients[clientId2].SendCh:
+		if evt.GetAppMessage() != nil {
+			t.Fatal("sender should not receive its own AppMessage")
+		}
+	default:
+	}
+}

--- a/services/collab_service.go
+++ b/services/collab_service.go
@@ -173,7 +173,8 @@ func (s *CollabService) HandleAction(ctx context.Context, action *pb.CollabActio
 		*pb.CollabAction_SceneInitRequest,
 		*pb.CollabAction_SceneInitResponse,
 		*pb.CollabAction_CredentialsChanged,
-		*pb.CollabAction_TitleChanged:
+		*pb.CollabAction_TitleChanged,
+		*pb.CollabAction_AppMessage:
 		return s.handleBroadcast(ctx, action)
 	default:
 		return nil, fmt.Errorf("unknown or empty action type")
@@ -584,6 +585,13 @@ func (s *CollabService) handleBroadcast(ctx context.Context, action *pb.CollabAc
 		room.Title = a.TitleChanged.GetTitle()
 		room.mu.Unlock()
 		event.Event = &pb.CollabEvent_TitleChanged{TitleChanged: a.TitleChanged}
+	case *pb.CollabAction_AppMessage:
+		// Generic app-defined message: fanned out to the room unchanged, no
+		// server-side state and no editor semantics.
+		event.Event = &pb.CollabEvent_AppMessage{AppMessage: a.AppMessage}
+		if s.LogPayloads > 0 {
+			slog.Debug("AppMessage", "kind", a.AppMessage.GetKind(), "bytes", len(a.AppMessage.GetPayload()))
+		}
 	default:
 		return nil, fmt.Errorf("unsupported broadcast action type")
 	}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panyam/massrelay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/gen/massrelay/v1/models/collab_pb.js",
   "types": "dist/gen/massrelay/v1/models/collab_pb.d.ts",

--- a/ts/src/CollabClient.ts
+++ b/ts/src/CollabClient.ts
@@ -1,5 +1,6 @@
 import { GRPCWSClient } from '@panyam/servicekit-client';
 import { fromJson, type JsonValue } from '@bufbuild/protobuf';
+import { base64Encode } from '@bufbuild/protobuf/wire';
 import type { CollabActionJson, PeerInfoJson } from './gen/massrelay/v1/models/collab_pb.js';
 import type { CollabEvent } from './gen/massrelay/v1/models/collab_pb.js';
 import { CollabEventSchema } from './gen/massrelay/v1/models/collab_pb.js';
@@ -16,6 +17,8 @@ export interface CollabClientOptions {
   onOwnerChanged?: (newOwnerClientId: string) => void;
   onCredentialsChanged?: (reason: string) => void;
   onTitleChanged?: (title: string) => void;
+  /** A generic app-defined message another peer broadcast to the room. */
+  onAppMessage?: (kind: string, payload: Uint8Array) => void;
   /** Called when relay returns an ErrorEvent (e.g. ROOM_FULL). */
   onErrorEvent?: (code: string, message: string) => void;
   maxRetries?: number;
@@ -135,6 +138,13 @@ export class CollabClient {
       clientId: this._clientId,
       timestamp: String(Date.now()),
     });
+  }
+
+  /** Broadcast a generic app-defined message to the room (fanned out to all
+   * other peers). kind is an app-defined discriminator; payload is opaque bytes. */
+  sendAppMessage(kind: string, payload: Uint8Array): void {
+    // The JSON action encodes bytes as base64; keep the public API Uint8Array.
+    this.send({ appMessage: { kind, payload: base64Encode(payload) } });
   }
 
   private openWebSocket(): void {
@@ -287,6 +297,10 @@ export class CollabClient {
       case 'titleChanged':
         this._title = event.event.value.title;
         this.options.onTitleChanged?.(this._title);
+        break;
+
+      case 'appMessage':
+        this.options.onAppMessage?.(event.event.value.kind, event.event.value.payload);
         break;
     }
   }

--- a/ts/src/gen/massrelay/v1/models/collab_pb.ts
+++ b/ts/src/gen/massrelay/v1/models/collab_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file massrelay/v1/models/collab.proto.
  */
 export const file_massrelay_v1_models_collab: GenFile = /*@__PURE__*/
-  fileDesc("CiBtYXNzcmVsYXkvdjEvbW9kZWxzL2NvbGxhYi5wcm90bxITbWFzc3JlbGF5LnYxLm1vZGVscyKoBQoMQ29sbGFiQWN0aW9uEhEKCWFjdGlvbl9pZBgBIAEoCRIRCgljbGllbnRfaWQYAiABKAkSEQoJdGltZXN0YW1wGAMgASgDEi0KBGpvaW4YCiABKAsyHS5tYXNzcmVsYXkudjEubW9kZWxzLkpvaW5Sb29tSAASLwoFbGVhdmUYCyABKAsyHi5tYXNzcmVsYXkudjEubW9kZWxzLkxlYXZlUm9vbUgAEjcKCHByZXNlbmNlGAwgASgLMiMubWFzc3JlbGF5LnYxLm1vZGVscy5QcmVzZW5jZVVwZGF0ZUgAEjgKDHNjZW5lX3VwZGF0ZRgNIAEoCzIgLm1hc3NyZWxheS52MS5tb2RlbHMuU2NlbmVVcGRhdGVIABI6Cg1jdXJzb3JfdXBkYXRlGA4gASgLMiEubWFzc3JlbGF5LnYxLm1vZGVscy5DdXJzb3JVcGRhdGVIABI2Cgt0ZXh0X3VwZGF0ZRgPIAEoCzIfLm1hc3NyZWxheS52MS5tb2RlbHMuVGV4dFVwZGF0ZUgAEkMKEnNjZW5lX2luaXRfcmVxdWVzdBgQIAEoCzIlLm1hc3NyZWxheS52MS5tb2RlbHMuU2NlbmVJbml0UmVxdWVzdEgAEkUKE3NjZW5lX2luaXRfcmVzcG9uc2UYESABKAsyJi5tYXNzcmVsYXkudjEubW9kZWxzLlNjZW5lSW5pdFJlc3BvbnNlSAASRgoTY3JlZGVudGlhbHNfY2hhbmdlZBgSIAEoCzInLm1hc3NyZWxheS52MS5tb2RlbHMuQ3JlZGVudGlhbHNDaGFuZ2VkSAASOgoNdGl0bGVfY2hhbmdlZBgTIAEoCzIhLm1hc3NyZWxheS52MS5tb2RlbHMuVGl0bGVDaGFuZ2VkSABCCAoGYWN0aW9uIsACCghKb2luUm9vbRISCgpzZXNzaW9uX2lkGAEgASgJEhAKCHVzZXJuYW1lGAIgASgJEj0KCG1ldGFkYXRhGAMgAygLMisubWFzc3JlbGF5LnYxLm1vZGVscy5Kb2luUm9vbS5NZXRhZGF0YUVudHJ5EhMKC2NsaWVudF90eXBlGAQgASgJEhIKCmF2YXRhcl91cmwYBSABKAkSEAoIaXNfb3duZXIYBiABKAgSEgoKYnJvd3Nlcl9pZBgHIAEoCRITCgtjbGllbnRfaGludBgIIAEoCRIYChBwcm90b2NvbF92ZXJzaW9uGAkgASgFEhEKCWVuY3J5cHRlZBgKIAEoCBINCgV0aXRsZRgLIAEoCRovCg1NZXRhZGF0YUVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiGwoJTGVhdmVSb29tEg4KBnJlYXNvbhgBIAEoCSI1Cg5QcmVzZW5jZVVwZGF0ZRIRCglpc19hY3RpdmUYASABKAgSEAoIdXNlcm5hbWUYAiABKAkiQwoLU2NlbmVVcGRhdGUSNAoIZWxlbWVudHMYASADKAsyIi5tYXNzcmVsYXkudjEubW9kZWxzLkVsZW1lbnRVcGRhdGUiYgoNRWxlbWVudFVwZGF0ZRIKCgJpZBgBIAEoCRIPCgd2ZXJzaW9uGAIgASgFEhUKDXZlcnNpb25fbm9uY2UYAyABKAUSDAoEZGF0YRgEIAEoCRIPCgdkZWxldGVkGAUgASgIItYBCgxDdXJzb3JVcGRhdGUSCQoBeBgBIAEoAhIJCgF5GAIgASgCEgwKBHRvb2wYAyABKAkSDgoGYnV0dG9uGAQgASgJElcKFHNlbGVjdGVkX2VsZW1lbnRfaWRzGAUgAygLMjkubWFzc3JlbGF5LnYxLm1vZGVscy5DdXJzb3JVcGRhdGUuU2VsZWN0ZWRFbGVtZW50SWRzRW50cnkaOQoXU2VsZWN0ZWRFbGVtZW50SWRzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgIOgI4ASJECgpUZXh0VXBkYXRlEgwKBHRleHQYASABKAkSDwoHdmVyc2lvbhgCIAEoBRIXCg9jdXJzb3JfcG9zaXRpb24YAyABKAUiEgoQU2NlbmVJbml0UmVxdWVzdCIkChFTY2VuZUluaXRSZXNwb25zZRIPCgdwYXlsb2FkGAEgASgJIp8HCgtDb2xsYWJFdmVudBIQCghldmVudF9pZBgBIAEoCRIWCg5mcm9tX2NsaWVudF9pZBgCIAEoCRIYChBzZXJ2ZXJfdGltZXN0YW1wGAMgASgDEjYKC3Jvb21fam9pbmVkGAogASgLMh8ubWFzc3JlbGF5LnYxLm1vZGVscy5Sb29tSm9pbmVkSAASNgoLcGVlcl9qb2luZWQYCyABKAsyHy5tYXNzcmVsYXkudjEubW9kZWxzLlBlZXJKb2luZWRIABIyCglwZWVyX2xlZnQYDCABKAsyHS5tYXNzcmVsYXkudjEubW9kZWxzLlBlZXJMZWZ0SAASNwoIcHJlc2VuY2UYDSABKAsyIy5tYXNzcmVsYXkudjEubW9kZWxzLlByZXNlbmNlVXBkYXRlSAASOAoMc2NlbmVfdXBkYXRlGA4gASgLMiAubWFzc3JlbGF5LnYxLm1vZGVscy5TY2VuZVVwZGF0ZUgAEjoKDWN1cnNvcl91cGRhdGUYDyABKAsyIS5tYXNzcmVsYXkudjEubW9kZWxzLkN1cnNvclVwZGF0ZUgAEjYKC3RleHRfdXBkYXRlGBAgASgLMh8ubWFzc3JlbGF5LnYxLm1vZGVscy5UZXh0VXBkYXRlSAASRQoTc2NlbmVfaW5pdF9yZXNwb25zZRgRIAEoCzImLm1hc3NyZWxheS52MS5tb2RlbHMuU2NlbmVJbml0UmVzcG9uc2VIABIwCgVlcnJvchgSIAEoCzIfLm1hc3NyZWxheS52MS5tb2RlbHMuRXJyb3JFdmVudEgAEkMKEnNjZW5lX2luaXRfcmVxdWVzdBgTIAEoCzIlLm1hc3NyZWxheS52MS5tb2RlbHMuU2NlbmVJbml0UmVxdWVzdEgAEjoKDXNlc3Npb25fZW5kZWQYFCABKAsyIS5tYXNzcmVsYXkudjEubW9kZWxzLlNlc3Npb25FbmRlZEgAEjoKDW93bmVyX2NoYW5nZWQYFSABKAsyIS5tYXNzcmVsYXkudjEubW9kZWxzLk93bmVyQ2hhbmdlZEgAEkYKE2NyZWRlbnRpYWxzX2NoYW5nZWQYFiABKAsyJy5tYXNzcmVsYXkudjEubW9kZWxzLkNyZWRlbnRpYWxzQ2hhbmdlZEgAEjoKDXRpdGxlX2NoYW5nZWQYFyABKAsyIS5tYXNzcmVsYXkudjEubW9kZWxzLlRpdGxlQ2hhbmdlZEgAQgcKBWV2ZW50IvMCCgRSb29tEhIKCnNlc3Npb25faWQYASABKAkSMwoFcGVlcnMYAiADKAsyJC5tYXNzcmVsYXkudjEubW9kZWxzLlJvb20uUGVlcnNFbnRyeRIXCg9vd25lcl9jbGllbnRfaWQYAyABKAkSLgoKY3JlYXRlZF9hdBgEIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASOQoIbWV0YWRhdGEYBSADKAsyJy5tYXNzcmVsYXkudjEubW9kZWxzLlJvb20uTWV0YWRhdGFFbnRyeRIRCgllbmNyeXB0ZWQYBiABKAgSDQoFdGl0bGUYByABKAkaSwoKUGVlcnNFbnRyeRILCgNrZXkYASABKAkSLAoFdmFsdWUYAiABKAsyHS5tYXNzcmVsYXkudjEubW9kZWxzLlBlZXJJbmZvOgI4ARovCg1NZXRhZGF0YUVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEidQoKUm9vbUpvaW5lZBIRCgljbGllbnRfaWQYASABKAkSJwoEcm9vbRgCIAEoCzIZLm1hc3NyZWxheS52MS5tb2RlbHMuUm9vbRIRCgltYXhfcGVlcnMYBSABKAUSGAoQcHJvdG9jb2xfdmVyc2lvbhgHIAEoBSLtAQoIUGVlckluZm8SEQoJY2xpZW50X2lkGAEgASgJEhAKCHVzZXJuYW1lGAIgASgJEhIKCmF2YXRhcl91cmwYAyABKAkSEwoLY2xpZW50X3R5cGUYBCABKAkSEQoJaXNfYWN0aXZlGAUgASgIEhAKCGlzX293bmVyGAYgASgIEj0KCG1ldGFkYXRhGAcgAygLMisubWFzc3JlbGF5LnYxLm1vZGVscy5QZWVySW5mby5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASI5CgpQZWVySm9pbmVkEisKBHBlZXIYASABKAsyHS5tYXNzcmVsYXkudjEubW9kZWxzLlBlZXJJbmZvIkEKCFBlZXJMZWZ0EhEKCWNsaWVudF9pZBgBIAEoCRIOCgZyZWFzb24YAiABKAkSEgoKcGVlcl9jb3VudBgDIAEoBSIrCgpFcnJvckV2ZW50EgwKBGNvZGUYASABKAkSDwoHbWVzc2FnZRgCIAEoCSIeCgxTZXNzaW9uRW5kZWQSDgoGcmVhc29uGAEgASgJIisKDE93bmVyQ2hhbmdlZBIbChNuZXdfb3duZXJfY2xpZW50X2lkGAEgASgJIiQKEkNyZWRlbnRpYWxzQ2hhbmdlZBIOCgZyZWFzb24YASABKAkiHQoMVGl0bGVDaGFuZ2VkEg0KBXRpdGxlGAEgASgJIiQKDkdldFJvb21SZXF1ZXN0EhIKCnNlc3Npb25faWQYASABKAkiOgoPR2V0Um9vbVJlc3BvbnNlEicKBHJvb20YASABKAsyGS5tYXNzcmVsYXkudjEubW9kZWxzLlJvb20iEgoQTGlzdFJvb21zUmVxdWVzdCJEChFMaXN0Um9vbXNSZXNwb25zZRIvCgVyb29tcxgBIAMoCzIgLm1hc3NyZWxheS52MS5tb2RlbHMuUm9vbVN1bW1hcnkiZQoLUm9vbVN1bW1hcnkSEgoKc2Vzc2lvbl9pZBgBIAEoCRISCgpwZWVyX2NvdW50GAIgASgFEi4KCmNyZWF0ZWRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wQswBChdjb20ubWFzc3JlbGF5LnYxLm1vZGVsc0ILQ29sbGFiUHJvdG9QAVo2Z2l0aHViLmNvbS9wYW55YW0vbWFzc3JlbGF5L2dlbi9nby9tYXNzcmVsYXkvdjEvbW9kZWxzogIDTVZNqgITTWFzc3JlbGF5LlYxLk1vZGVsc8oCE01hc3NyZWxheVxWMVxNb2RlbHPiAh9NYXNzcmVsYXlcVjFcTW9kZWxzXEdQQk1ldGFkYXRh6gIVTWFzc3JlbGF5OjpWMTo6TW9kZWxzYgZwcm90bzM", [file_google_protobuf_timestamp]);
+  fileDesc("CiBtYXNzcmVsYXkvdjEvbW9kZWxzL2NvbGxhYi5wcm90bxITbWFzc3JlbGF5LnYxLm1vZGVscyLgBQoMQ29sbGFiQWN0aW9uEhEKCWFjdGlvbl9pZBgBIAEoCRIRCgljbGllbnRfaWQYAiABKAkSEQoJdGltZXN0YW1wGAMgASgDEi0KBGpvaW4YCiABKAsyHS5tYXNzcmVsYXkudjEubW9kZWxzLkpvaW5Sb29tSAASLwoFbGVhdmUYCyABKAsyHi5tYXNzcmVsYXkudjEubW9kZWxzLkxlYXZlUm9vbUgAEjcKCHByZXNlbmNlGAwgASgLMiMubWFzc3JlbGF5LnYxLm1vZGVscy5QcmVzZW5jZVVwZGF0ZUgAEjgKDHNjZW5lX3VwZGF0ZRgNIAEoCzIgLm1hc3NyZWxheS52MS5tb2RlbHMuU2NlbmVVcGRhdGVIABI6Cg1jdXJzb3JfdXBkYXRlGA4gASgLMiEubWFzc3JlbGF5LnYxLm1vZGVscy5DdXJzb3JVcGRhdGVIABI2Cgt0ZXh0X3VwZGF0ZRgPIAEoCzIfLm1hc3NyZWxheS52MS5tb2RlbHMuVGV4dFVwZGF0ZUgAEkMKEnNjZW5lX2luaXRfcmVxdWVzdBgQIAEoCzIlLm1hc3NyZWxheS52MS5tb2RlbHMuU2NlbmVJbml0UmVxdWVzdEgAEkUKE3NjZW5lX2luaXRfcmVzcG9uc2UYESABKAsyJi5tYXNzcmVsYXkudjEubW9kZWxzLlNjZW5lSW5pdFJlc3BvbnNlSAASRgoTY3JlZGVudGlhbHNfY2hhbmdlZBgSIAEoCzInLm1hc3NyZWxheS52MS5tb2RlbHMuQ3JlZGVudGlhbHNDaGFuZ2VkSAASOgoNdGl0bGVfY2hhbmdlZBgTIAEoCzIhLm1hc3NyZWxheS52MS5tb2RlbHMuVGl0bGVDaGFuZ2VkSAASNgoLYXBwX21lc3NhZ2UYFCABKAsyHy5tYXNzcmVsYXkudjEubW9kZWxzLkFwcE1lc3NhZ2VIAEIICgZhY3Rpb24iwAIKCEpvaW5Sb29tEhIKCnNlc3Npb25faWQYASABKAkSEAoIdXNlcm5hbWUYAiABKAkSPQoIbWV0YWRhdGEYAyADKAsyKy5tYXNzcmVsYXkudjEubW9kZWxzLkpvaW5Sb29tLk1ldGFkYXRhRW50cnkSEwoLY2xpZW50X3R5cGUYBCABKAkSEgoKYXZhdGFyX3VybBgFIAEoCRIQCghpc19vd25lchgGIAEoCBISCgpicm93c2VyX2lkGAcgASgJEhMKC2NsaWVudF9oaW50GAggASgJEhgKEHByb3RvY29sX3ZlcnNpb24YCSABKAUSEQoJZW5jcnlwdGVkGAogASgIEg0KBXRpdGxlGAsgASgJGi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASIbCglMZWF2ZVJvb20SDgoGcmVhc29uGAEgASgJIjUKDlByZXNlbmNlVXBkYXRlEhEKCWlzX2FjdGl2ZRgBIAEoCBIQCgh1c2VybmFtZRgCIAEoCSJDCgtTY2VuZVVwZGF0ZRI0CghlbGVtZW50cxgBIAMoCzIiLm1hc3NyZWxheS52MS5tb2RlbHMuRWxlbWVudFVwZGF0ZSJiCg1FbGVtZW50VXBkYXRlEgoKAmlkGAEgASgJEg8KB3ZlcnNpb24YAiABKAUSFQoNdmVyc2lvbl9ub25jZRgDIAEoBRIMCgRkYXRhGAQgASgJEg8KB2RlbGV0ZWQYBSABKAgi1gEKDEN1cnNvclVwZGF0ZRIJCgF4GAEgASgCEgkKAXkYAiABKAISDAoEdG9vbBgDIAEoCRIOCgZidXR0b24YBCABKAkSVwoUc2VsZWN0ZWRfZWxlbWVudF9pZHMYBSADKAsyOS5tYXNzcmVsYXkudjEubW9kZWxzLkN1cnNvclVwZGF0ZS5TZWxlY3RlZEVsZW1lbnRJZHNFbnRyeRo5ChdTZWxlY3RlZEVsZW1lbnRJZHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAg6AjgBIkQKClRleHRVcGRhdGUSDAoEdGV4dBgBIAEoCRIPCgd2ZXJzaW9uGAIgASgFEhcKD2N1cnNvcl9wb3NpdGlvbhgDIAEoBSISChBTY2VuZUluaXRSZXF1ZXN0IiQKEVNjZW5lSW5pdFJlc3BvbnNlEg8KB3BheWxvYWQYASABKAkiKwoKQXBwTWVzc2FnZRIMCgRraW5kGAEgASgJEg8KB3BheWxvYWQYAiABKAwi1wcKC0NvbGxhYkV2ZW50EhAKCGV2ZW50X2lkGAEgASgJEhYKDmZyb21fY2xpZW50X2lkGAIgASgJEhgKEHNlcnZlcl90aW1lc3RhbXAYAyABKAMSNgoLcm9vbV9qb2luZWQYCiABKAsyHy5tYXNzcmVsYXkudjEubW9kZWxzLlJvb21Kb2luZWRIABI2CgtwZWVyX2pvaW5lZBgLIAEoCzIfLm1hc3NyZWxheS52MS5tb2RlbHMuUGVlckpvaW5lZEgAEjIKCXBlZXJfbGVmdBgMIAEoCzIdLm1hc3NyZWxheS52MS5tb2RlbHMuUGVlckxlZnRIABI3CghwcmVzZW5jZRgNIAEoCzIjLm1hc3NyZWxheS52MS5tb2RlbHMuUHJlc2VuY2VVcGRhdGVIABI4CgxzY2VuZV91cGRhdGUYDiABKAsyIC5tYXNzcmVsYXkudjEubW9kZWxzLlNjZW5lVXBkYXRlSAASOgoNY3Vyc29yX3VwZGF0ZRgPIAEoCzIhLm1hc3NyZWxheS52MS5tb2RlbHMuQ3Vyc29yVXBkYXRlSAASNgoLdGV4dF91cGRhdGUYECABKAsyHy5tYXNzcmVsYXkudjEubW9kZWxzLlRleHRVcGRhdGVIABJFChNzY2VuZV9pbml0X3Jlc3BvbnNlGBEgASgLMiYubWFzc3JlbGF5LnYxLm1vZGVscy5TY2VuZUluaXRSZXNwb25zZUgAEjAKBWVycm9yGBIgASgLMh8ubWFzc3JlbGF5LnYxLm1vZGVscy5FcnJvckV2ZW50SAASQwoSc2NlbmVfaW5pdF9yZXF1ZXN0GBMgASgLMiUubWFzc3JlbGF5LnYxLm1vZGVscy5TY2VuZUluaXRSZXF1ZXN0SAASOgoNc2Vzc2lvbl9lbmRlZBgUIAEoCzIhLm1hc3NyZWxheS52MS5tb2RlbHMuU2Vzc2lvbkVuZGVkSAASOgoNb3duZXJfY2hhbmdlZBgVIAEoCzIhLm1hc3NyZWxheS52MS5tb2RlbHMuT3duZXJDaGFuZ2VkSAASRgoTY3JlZGVudGlhbHNfY2hhbmdlZBgWIAEoCzInLm1hc3NyZWxheS52MS5tb2RlbHMuQ3JlZGVudGlhbHNDaGFuZ2VkSAASOgoNdGl0bGVfY2hhbmdlZBgXIAEoCzIhLm1hc3NyZWxheS52MS5tb2RlbHMuVGl0bGVDaGFuZ2VkSAASNgoLYXBwX21lc3NhZ2UYGCABKAsyHy5tYXNzcmVsYXkudjEubW9kZWxzLkFwcE1lc3NhZ2VIAEIHCgVldmVudCLzAgoEUm9vbRISCgpzZXNzaW9uX2lkGAEgASgJEjMKBXBlZXJzGAIgAygLMiQubWFzc3JlbGF5LnYxLm1vZGVscy5Sb29tLlBlZXJzRW50cnkSFwoPb3duZXJfY2xpZW50X2lkGAMgASgJEi4KCmNyZWF0ZWRfYXQYBCABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEjkKCG1ldGFkYXRhGAUgAygLMicubWFzc3JlbGF5LnYxLm1vZGVscy5Sb29tLk1ldGFkYXRhRW50cnkSEQoJZW5jcnlwdGVkGAYgASgIEg0KBXRpdGxlGAcgASgJGksKClBlZXJzRW50cnkSCwoDa2V5GAEgASgJEiwKBXZhbHVlGAIgASgLMh0ubWFzc3JlbGF5LnYxLm1vZGVscy5QZWVySW5mbzoCOAEaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBInUKClJvb21Kb2luZWQSEQoJY2xpZW50X2lkGAEgASgJEicKBHJvb20YAiABKAsyGS5tYXNzcmVsYXkudjEubW9kZWxzLlJvb20SEQoJbWF4X3BlZXJzGAUgASgFEhgKEHByb3RvY29sX3ZlcnNpb24YByABKAUi7QEKCFBlZXJJbmZvEhEKCWNsaWVudF9pZBgBIAEoCRIQCgh1c2VybmFtZRgCIAEoCRISCgphdmF0YXJfdXJsGAMgASgJEhMKC2NsaWVudF90eXBlGAQgASgJEhEKCWlzX2FjdGl2ZRgFIAEoCBIQCghpc19vd25lchgGIAEoCBI9CghtZXRhZGF0YRgHIAMoCzIrLm1hc3NyZWxheS52MS5tb2RlbHMuUGVlckluZm8uTWV0YWRhdGFFbnRyeRovCg1NZXRhZGF0YUVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiOQoKUGVlckpvaW5lZBIrCgRwZWVyGAEgASgLMh0ubWFzc3JlbGF5LnYxLm1vZGVscy5QZWVySW5mbyJBCghQZWVyTGVmdBIRCgljbGllbnRfaWQYASABKAkSDgoGcmVhc29uGAIgASgJEhIKCnBlZXJfY291bnQYAyABKAUiKwoKRXJyb3JFdmVudBIMCgRjb2RlGAEgASgJEg8KB21lc3NhZ2UYAiABKAkiHgoMU2Vzc2lvbkVuZGVkEg4KBnJlYXNvbhgBIAEoCSIrCgxPd25lckNoYW5nZWQSGwoTbmV3X293bmVyX2NsaWVudF9pZBgBIAEoCSIkChJDcmVkZW50aWFsc0NoYW5nZWQSDgoGcmVhc29uGAEgASgJIh0KDFRpdGxlQ2hhbmdlZBINCgV0aXRsZRgBIAEoCSIkCg5HZXRSb29tUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJIjoKD0dldFJvb21SZXNwb25zZRInCgRyb29tGAEgASgLMhkubWFzc3JlbGF5LnYxLm1vZGVscy5Sb29tIhIKEExpc3RSb29tc1JlcXVlc3QiRAoRTGlzdFJvb21zUmVzcG9uc2USLwoFcm9vbXMYASADKAsyIC5tYXNzcmVsYXkudjEubW9kZWxzLlJvb21TdW1tYXJ5ImUKC1Jvb21TdW1tYXJ5EhIKCnNlc3Npb25faWQYASABKAkSEgoKcGVlcl9jb3VudBgCIAEoBRIuCgpjcmVhdGVkX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcELMAQoXY29tLm1hc3NyZWxheS52MS5tb2RlbHNCC0NvbGxhYlByb3RvUAFaNmdpdGh1Yi5jb20vcGFueWFtL21hc3NyZWxheS9nZW4vZ28vbWFzc3JlbGF5L3YxL21vZGVsc6ICA01WTaoCE01hc3NyZWxheS5WMS5Nb2RlbHPKAhNNYXNzcmVsYXlcVjFcTW9kZWxz4gIfTWFzc3JlbGF5XFYxXE1vZGVsc1xHUEJNZXRhZGF0YeoCFU1hc3NyZWxheTo6VjE6Ok1vZGVsc2IGcHJvdG8z", [file_google_protobuf_timestamp]);
 
 /**
  * @generated from message massrelay.v1.models.CollabAction
@@ -98,6 +98,16 @@ export type CollabAction = Message<"massrelay.v1.models.CollabAction"> & {
      */
     value: TitleChanged;
     case: "titleChanged";
+  } | {
+    /**
+     * Generic, app-defined pub-sub message (no editor semantics). Relay-only:
+     * fanned out to the room unchanged, so any application can use massrelay as a
+     * message bus without adopting the editor (Scene/Text) protocol.
+     *
+     * @generated from field: massrelay.v1.models.AppMessage app_message = 20;
+     */
+    value: AppMessage;
+    case: "appMessage";
   } | { case: undefined; value?: undefined };
 };
 
@@ -171,6 +181,15 @@ export type CollabActionJson = {
    * @generated from field: massrelay.v1.models.TitleChanged title_changed = 19;
    */
   titleChanged?: TitleChangedJson;
+
+  /**
+   * Generic, app-defined pub-sub message (no editor semantics). Relay-only:
+   * fanned out to the room unchanged, so any application can use massrelay as a
+   * message bus without adopting the editor (Scene/Text) protocol.
+   *
+   * @generated from field: massrelay.v1.models.AppMessage app_message = 20;
+   */
+  appMessage?: AppMessageJson;
 };
 
 /**
@@ -672,6 +691,53 @@ export const SceneInitResponseSchema: GenMessage<SceneInitResponse, {jsonType: S
   messageDesc(file_massrelay_v1_models_collab, 9);
 
 /**
+ * AppMessage is a generic, application-defined message the relay fans out to the
+ * room unchanged (no server-side state, no editor semantics). kind is an
+ * app-defined discriminator so peers route without decoding; payload is opaque
+ * bytes whose schema the application owns.
+ *
+ * @generated from message massrelay.v1.models.AppMessage
+ */
+export type AppMessage = Message<"massrelay.v1.models.AppMessage"> & {
+  /**
+   * @generated from field: string kind = 1;
+   */
+  kind: string;
+
+  /**
+   * @generated from field: bytes payload = 2;
+   */
+  payload: Uint8Array;
+};
+
+/**
+ * AppMessage is a generic, application-defined message the relay fans out to the
+ * room unchanged (no server-side state, no editor semantics). kind is an
+ * app-defined discriminator so peers route without decoding; payload is opaque
+ * bytes whose schema the application owns.
+ *
+ * @generated from message massrelay.v1.models.AppMessage
+ */
+export type AppMessageJson = {
+  /**
+   * @generated from field: string kind = 1;
+   */
+  kind?: string;
+
+  /**
+   * @generated from field: bytes payload = 2;
+   */
+  payload?: string;
+};
+
+/**
+ * Describes the message massrelay.v1.models.AppMessage.
+ * Use `create(AppMessageSchema)` to create a new message.
+ */
+export const AppMessageSchema: GenMessage<AppMessage, {jsonType: AppMessageJson}> = /*@__PURE__*/
+  messageDesc(file_massrelay_v1_models_collab, 10);
+
+/**
  * @generated from message massrelay.v1.models.CollabEvent
  */
 export type CollabEvent = Message<"massrelay.v1.models.CollabEvent"> & {
@@ -779,6 +845,15 @@ export type CollabEvent = Message<"massrelay.v1.models.CollabEvent"> & {
      */
     value: TitleChanged;
     case: "titleChanged";
+  } | {
+    /**
+     * Generic, app-defined pub-sub message fanned out to the room (see the
+     * matching CollabAction.app_message).
+     *
+     * @generated from field: massrelay.v1.models.AppMessage app_message = 24;
+     */
+    value: AppMessage;
+    case: "appMessage";
   } | { case: undefined; value?: undefined };
 };
 
@@ -872,6 +947,14 @@ export type CollabEventJson = {
    * @generated from field: massrelay.v1.models.TitleChanged title_changed = 23;
    */
   titleChanged?: TitleChangedJson;
+
+  /**
+   * Generic, app-defined pub-sub message fanned out to the room (see the
+   * matching CollabAction.app_message).
+   *
+   * @generated from field: massrelay.v1.models.AppMessage app_message = 24;
+   */
+  appMessage?: AppMessageJson;
 };
 
 /**
@@ -879,7 +962,7 @@ export type CollabEventJson = {
  * Use `create(CollabEventSchema)` to create a new message.
  */
 export const CollabEventSchema: GenMessage<CollabEvent, {jsonType: CollabEventJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 10);
+  messageDesc(file_massrelay_v1_models_collab, 11);
 
 /**
  * Room captures the canonical state of a collaboration session.
@@ -980,7 +1063,7 @@ export type RoomJson = {
  * Use `create(RoomSchema)` to create a new message.
  */
 export const RoomSchema: GenMessage<Room, {jsonType: RoomJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 11);
+  messageDesc(file_massrelay_v1_models_collab, 12);
 
 /**
  * @generated from message massrelay.v1.models.RoomJoined
@@ -1045,7 +1128,7 @@ export type RoomJoinedJson = {
  * Use `create(RoomJoinedSchema)` to create a new message.
  */
 export const RoomJoinedSchema: GenMessage<RoomJoined, {jsonType: RoomJoinedJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 12);
+  messageDesc(file_massrelay_v1_models_collab, 13);
 
 /**
  * @generated from message massrelay.v1.models.PeerInfo
@@ -1136,7 +1219,7 @@ export type PeerInfoJson = {
  * Use `create(PeerInfoSchema)` to create a new message.
  */
 export const PeerInfoSchema: GenMessage<PeerInfo, {jsonType: PeerInfoJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 13);
+  messageDesc(file_massrelay_v1_models_collab, 14);
 
 /**
  * @generated from message massrelay.v1.models.PeerJoined
@@ -1163,7 +1246,7 @@ export type PeerJoinedJson = {
  * Use `create(PeerJoinedSchema)` to create a new message.
  */
 export const PeerJoinedSchema: GenMessage<PeerJoined, {jsonType: PeerJoinedJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 14);
+  messageDesc(file_massrelay_v1_models_collab, 15);
 
 /**
  * @generated from message massrelay.v1.models.PeerLeft
@@ -1210,7 +1293,7 @@ export type PeerLeftJson = {
  * Use `create(PeerLeftSchema)` to create a new message.
  */
 export const PeerLeftSchema: GenMessage<PeerLeft, {jsonType: PeerLeftJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 15);
+  messageDesc(file_massrelay_v1_models_collab, 16);
 
 /**
  * @generated from message massrelay.v1.models.ErrorEvent
@@ -1247,7 +1330,7 @@ export type ErrorEventJson = {
  * Use `create(ErrorEventSchema)` to create a new message.
  */
 export const ErrorEventSchema: GenMessage<ErrorEvent, {jsonType: ErrorEventJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 16);
+  messageDesc(file_massrelay_v1_models_collab, 17);
 
 /**
  * @generated from message massrelay.v1.models.SessionEnded
@@ -1274,7 +1357,7 @@ export type SessionEndedJson = {
  * Use `create(SessionEndedSchema)` to create a new message.
  */
 export const SessionEndedSchema: GenMessage<SessionEnded, {jsonType: SessionEndedJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 17);
+  messageDesc(file_massrelay_v1_models_collab, 18);
 
 /**
  * @generated from message massrelay.v1.models.OwnerChanged
@@ -1301,7 +1384,7 @@ export type OwnerChangedJson = {
  * Use `create(OwnerChangedSchema)` to create a new message.
  */
 export const OwnerChangedSchema: GenMessage<OwnerChanged, {jsonType: OwnerChangedJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 18);
+  messageDesc(file_massrelay_v1_models_collab, 19);
 
 /**
  * @generated from message massrelay.v1.models.CredentialsChanged
@@ -1332,7 +1415,7 @@ export type CredentialsChangedJson = {
  * Use `create(CredentialsChangedSchema)` to create a new message.
  */
 export const CredentialsChangedSchema: GenMessage<CredentialsChanged, {jsonType: CredentialsChangedJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 19);
+  messageDesc(file_massrelay_v1_models_collab, 20);
 
 /**
  * @generated from message massrelay.v1.models.TitleChanged
@@ -1363,7 +1446,7 @@ export type TitleChangedJson = {
  * Use `create(TitleChangedSchema)` to create a new message.
  */
 export const TitleChangedSchema: GenMessage<TitleChanged, {jsonType: TitleChangedJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 20);
+  messageDesc(file_massrelay_v1_models_collab, 21);
 
 /**
  * @generated from message massrelay.v1.models.GetRoomRequest
@@ -1390,7 +1473,7 @@ export type GetRoomRequestJson = {
  * Use `create(GetRoomRequestSchema)` to create a new message.
  */
 export const GetRoomRequestSchema: GenMessage<GetRoomRequest, {jsonType: GetRoomRequestJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 21);
+  messageDesc(file_massrelay_v1_models_collab, 22);
 
 /**
  * @generated from message massrelay.v1.models.GetRoomResponse
@@ -1417,7 +1500,7 @@ export type GetRoomResponseJson = {
  * Use `create(GetRoomResponseSchema)` to create a new message.
  */
 export const GetRoomResponseSchema: GenMessage<GetRoomResponse, {jsonType: GetRoomResponseJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 22);
+  messageDesc(file_massrelay_v1_models_collab, 23);
 
 /**
  * @generated from message massrelay.v1.models.ListRoomsRequest
@@ -1436,7 +1519,7 @@ export type ListRoomsRequestJson = {
  * Use `create(ListRoomsRequestSchema)` to create a new message.
  */
 export const ListRoomsRequestSchema: GenMessage<ListRoomsRequest, {jsonType: ListRoomsRequestJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 23);
+  messageDesc(file_massrelay_v1_models_collab, 24);
 
 /**
  * @generated from message massrelay.v1.models.ListRoomsResponse
@@ -1463,7 +1546,7 @@ export type ListRoomsResponseJson = {
  * Use `create(ListRoomsResponseSchema)` to create a new message.
  */
 export const ListRoomsResponseSchema: GenMessage<ListRoomsResponse, {jsonType: ListRoomsResponseJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 24);
+  messageDesc(file_massrelay_v1_models_collab, 25);
 
 /**
  * @generated from message massrelay.v1.models.RoomSummary
@@ -1510,5 +1593,5 @@ export type RoomSummaryJson = {
  * Use `create(RoomSummarySchema)` to create a new message.
  */
 export const RoomSummarySchema: GenMessage<RoomSummary, {jsonType: RoomSummaryJson}> = /*@__PURE__*/
-  messageDesc(file_massrelay_v1_models_collab, 25);
+  messageDesc(file_massrelay_v1_models_collab, 26);
 


### PR DESCRIPTION
## What changes

Add a generic **`AppMessage { kind, payload }`** to the collab protocol so any application can use massrelay as a **room pub-sub bus** without adopting the editor (Scene/Text) protocol. The relay fans it out to the room unchanged — **no server-side state, no editor semantics** — via the existing `handleBroadcast` path.

Motivating consumer: diffpp's review workspace (VW-023) needs to fan out review answers + agent-roster changes to all browser windows on a `review_id` room. The existing payload-bearing events (`TextUpdate`, `SceneInitResponse`) are bound to the editor/document model (version/cursor fields, `SyncAdapter` schema ownership, `LogPayloads` content logging), so carrying app data in them would be a semantic abuse and fragile against future CRDT/versioning. `AppMessage` is the neutral primitive.

## Reviewer's guide
Read in this order:
1. `protos/massrelay/v1/models/collab.proto` — the `AppMessage` message + `app_message` in both oneofs.
2. `services/collab_service.go` — the `AppMessage` case added to the broadcast dispatch + `handleBroadcast` (pure fan-out, no `Room` mutation).
3. `services/broadcast_test.go` — `TestBroadcastAppMessage`: a peer publishes, the other receives it verbatim (kind+payload), the sender does not echo (`BroadcastExcept`).
4. `ts/src/CollabClient.ts` — `sendAppMessage(kind, payload)` + the `onAppMessage` option + the `appMessage` dispatch case.

Skim/skip: `gen/` (regenerated).

## Decision log
- **`{ kind, payload: bytes }`**, not opaque-bytes-only: `kind` lets peers route without decoding; `payload` stays schema-neutral bytes (any app encoding).
- **Room-wide fan-out only** (matches `BroadcastToAll`/`BroadcastExcept`). Per-recipient targeting (`repeated string to`, empty = all) is a clean additive follow-up if a use case needs whispering — not built now.
- **Reused `handleBroadcast`** (the "relay-only, no server-side state" path) rather than a new handler — `AppMessage` is exactly that shape.

## Risk / blast radius
- **Affects:** additive oneof fields (`CollabAction.app_message = 20`, `CollabEvent.app_message = 24`) + one service case + two client methods. Backward-compatible; existing editor flows untouched.
- **Tests:** `TestBroadcastAppMessage` (Go, wire behavior); full suite green (3 Go pkgs, 53 TS tests). TS client send/receive round-trip is an integration-test candidate (no client-mock harness exists yet).

## Before / after (observable)
```
# before: to carry app data you had to piggyback TextUpdate{ text, version, cursor } —
#         an editor edit, logged as content, fragile to future CRDT semantics.
# after:
  peerB.sendAppMessage("answer", <bytes>)
  -> peerA.onAppMessage("answer", <same bytes>)      # verbatim, room-wide
  -> peerB (sender)                                  # no echo (BroadcastExcept)
```

## Release / downstream
Version bumped 0.1.0 → 0.1.1 (additive, semver-minor). After merge + tag/release, **diffpp VW-023** bumps `github.com/panyam/massrelay` + `@panyam/massrelay` to 0.1.1 and does the browser-rooms integration (separate PR in the diffpp repo).
